### PR TITLE
chore: 사용자 목록 이미지 영역 확대

### DIFF
--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -19,4 +19,11 @@ export const COLORS: string[] = [
 
 export const DEFAULT_LINE_SIZE: number = 3;
 
-export const PROFILE_CHARACTERS = ['🐶', '🐱', '🐰', '🦊', '🐨', '🐼', '🐯', '🐥', '🐷'];
+// https://emojiterra.com/animals/
+// prettier-ignore
+export const PROFILE_CHARACTERS = [
+  '🐶', '🐱', '🦁', '🐰', '🦊', '🐨', '🐼', '🐯', '🐥', '🐷',
+  '🐮', '🐹', '🐻‍❄️', '🐸', '🐲', '🐳', '🐙', '🐔', '🦄', '🐺',
+  '🦥', '🦦', '🦭', '🦖', '🐢', 
+  '🦋', '🐛', '🐝', '🕷️', '🐌',
+];

--- a/frontend/src/pages/Room/components/GameTimer/index.scss
+++ b/frontend/src/pages/Room/components/GameTimer/index.scss
@@ -2,7 +2,7 @@
   position: relative;
   height: 40px;
   display: inline-flex;
-  justify-content: center;
+  justify-content: left;
   align-items: center;
 
   .timer-emoji {

--- a/frontend/src/pages/Room/containers/UserListContainer/index.scss
+++ b/frontend/src/pages/Room/containers/UserListContainer/index.scss
@@ -1,7 +1,26 @@
+@import '~styles/modules/mixin.scss';
+
 .user-list {
   list-style: none;
 
   li {
     position: relative;
+  }
+
+  .profile-wrap {
+    position: relative;
+    padding-left: 70px;
+
+    .profile-avatar {
+      position: absolute;
+      top: -4px;
+      left: -4px;
+      zoom: 1.8;
+    }
+  }
+
+  .nickname {
+    width: 100%;
+    @include ellipsis();
   }
 }

--- a/frontend/src/pages/Room/containers/UserListContainer/index.scss
+++ b/frontend/src/pages/Room/containers/UserListContainer/index.scss
@@ -13,7 +13,7 @@
 
     .profile-avatar {
       position: absolute;
-      top: -4px;
+      top: -7px;
       left: -4px;
       zoom: 1.8;
     }

--- a/frontend/src/pages/Room/containers/UserListContainer/index.tsx
+++ b/frontend/src/pages/Room/containers/UserListContainer/index.tsx
@@ -12,10 +12,12 @@ const UserListContainer = () => {
       {participants.map(({ userId, nickName, profileIndex }) => {
         return (
           <li key={userId}>
-            <Flex bg="white" margin={1} padding={2} borderRadius={6}>
+            <Flex className="profile-wrap" bg="white" margin={2} mb={4} padding={2} borderRadius={6}>
               <ProfileAvatar index={profileIndex} />
               <Box ml="3">
-                <Text fontWeight="bold">{nickName}</Text>
+                <Text className="nickname" fontWeight="bold">
+                  {nickName}
+                </Text>
                 <Badge colorScheme="green">0 points</Badge>
               </Box>
             </Flex>


### PR DESCRIPTION
## 🍯 작업 내용

조금 더 입체적인 느낌이 나도록 아바타 영역을 확대하였습니다. 귀시코감~!
<img width="433" alt="image" src="https://user-images.githubusercontent.com/1393664/166136587-bb986ede-1c3b-401a-b044-ce1ecd8b022e.png">
